### PR TITLE
Configurable axis remap

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Parameters:
 - **frame_id** (default: 'imu_link') - the frame in which sensor data will be published. 
 - **frequency** (default: 100) - the frequency of reading from device and publishing data in Hz.
 - **operation_mode** (default: OPER_MODE_NDOF) - the operation mode of sensor BNO055. Other modes could be found in sensor [datasheet](https://www.bosch-sensortec.com/bst/products/all_products/bno055).
+- **axis_remap_config** (default: 0x24) - the axis remap configuration. Refer to the datasheet page 27.
+- **axis_remap_sign** (default: 0x00) - the axis remap sign. Refer to the datasheet page 27.
 
 Publishes:
 - **/imu/data** [(sensor_msgs/Imu)](http://docs.ros.org/api/sensor_msgs/html/msg/Imu.html)

--- a/nodes/bosch_imu_node.py
+++ b/nodes/bosch_imu_node.py
@@ -161,6 +161,8 @@ if __name__ == '__main__':
     frame_id = rospy.get_param('~frame_id', 'imu_link')
     frequency = rospy.get_param('frequency', 100)
     operation_mode = rospy.get_param('operation_mode', OPER_MODE_NDOF)
+    axis_remap_config = rospy.get_param('~axis_remap_config', 0x24)
+    axis_remap_sign = rospy.get_param('~axis_remap_sign', 0x00)
 
     # Open serial port
     rospy.loginfo("Opening serial port: %s...", port)
@@ -192,10 +194,10 @@ if __name__ == '__main__':
     if not(write_to_dev(ser, UNIT_SEL, 1, 0x83)):
         rospy.logerr("Unable to set IMU units.")
 
-    if not(write_to_dev(ser, AXIS_MAP_CONFIG, 1, 0x24)):
+    if not(write_to_dev(ser, AXIS_MAP_CONFIG, 1, axis_remap_config)):
         rospy.logerr("Unable to remap IMU axis.")
 
-    if not(write_to_dev(ser, AXIS_MAP_SIGN, 1, 0x06)):
+    if not(write_to_dev(ser, AXIS_MAP_SIGN, 1, axis_remap_sign)):
         rospy.logerr("Unable to set IMU axis signs.")
 
     if not(write_to_dev(ser, OPER_MODE, 1, OPER_MODE_NDOF)):


### PR DESCRIPTION
Allow axis remapping via parameters. 

This comes in handy when the IMU on your robot is not oriented with the X axis forward.